### PR TITLE
Fix broken org.jetbrains.annotations dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -143,7 +143,7 @@ minecraft.runs.all {
     lazyToken("minecraft_classpath") {
         configurations.library.copyRecursive().resolve()
             .collect { it.absolutePath }
-            .findAll { !it.contains("org.jetbrains\\annotations\\13.0") && !it.contains("org.jetbrains/annotations/13.0") } // somewhat inelegantly remove duplicate
+            //.findAll { !it.contains("org.jetbrains\\annotations\\13.0") && !it.contains("org.jetbrains/annotations/13.0") } // somewhat inelegantly remove duplicate
             .join(File.pathSeparator)
     }
 }
@@ -176,7 +176,9 @@ configurations {
 
 dependencies {
     minecraft "net.minecraftforge:forge:$minecraft_version-$forge_version"
-    library "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    library ("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version") {
+        exclude group: 'org.jetbrains', module: 'annotations'
+    }
 
     // reload gradle and run genIntellijRuns (or eclipse) after changing
     def devModeREI = project.localProperties != null && project.localProperties.containsKey('dev.mode.rei') && Boolean.valueOf(project.localProperties.get("dev.mode.rei"))


### PR DESCRIPTION
Cleaner solution to avoid duplicate Jetbrains annotations dependencies in the classpath and fixes missing `org.jetbrains:annotations:13.0` dependency issues when using this mod as a Gradle dependency.